### PR TITLE
feat: logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "santa": "dist/cli/index.js"
   },
   "dependencies": {
+    "@types/lodash-es": "^4.17.3",
+    "@types/pino": "^5.15.1",
     "apollo-server-express": "^2.9.11",
     "arg": "^4.1.1",
     "chalk": "^3.0.0",
@@ -27,7 +29,10 @@
     "fs-jetpack": "^2.2.3",
     "graphql": "^14.5.8",
     "ink": "^2.5.0",
+    "lodash": "^4.17.15",
+    "lodash.merge": "^4.6.2",
     "nexus": "^0.12.0-rc.5",
+    "pino": "^5.15.0",
     "prompts": "^2.3.0",
     "react": "^16.12.0",
     "simple-git": "^1.126.0",
@@ -75,6 +80,7 @@
     "prepublishOnly": "yarn -s build",
     "test": "jest --verbose --testTimeout 120000",
     "test:dev": "jest --watch --verbose --testTimeout 120000",
+    "dev:test": "jest --watch --verbose --testRegex '.+/src/.+\\.spec\\.ts'",
     "dev": "tsc -b -w"
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "prepublishOnly": "yarn -s build",
     "test": "jest --verbose --testTimeout 120000",
     "test:dev": "jest --watch --verbose --testTimeout 120000",
-    "dev:test": "jest --watch --verbose --testRegex '.+/src/.+\\.spec\\.ts'",
+    "dev:test": "jest --watch --verbose --testRegex '.+/src/.+\\.spec\\.ts$'",
     "dev": "tsc -b -w"
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "santa": "dist/cli/index.js"
   },
   "dependencies": {
-    "@types/lodash-es": "^4.17.3",
     "@types/pino": "^5.15.1",
     "apollo-server-express": "^2.9.11",
     "arg": "^4.1.1",
@@ -30,7 +29,6 @@
     "graphql": "^14.5.8",
     "ink": "^2.5.0",
     "lodash": "^4.17.15",
-    "lodash.merge": "^4.6.2",
     "nexus": "^0.12.0-rc.5",
     "pino": "^5.15.0",
     "prompts": "^2.3.0",
@@ -47,6 +45,7 @@
     "@types/debug": "4.1.5",
     "@types/dotenv": "8.2.0",
     "@types/jest": "24.0.25",
+    "@types/lodash": "^4.14.149",
     "@types/node": "12.12.24",
     "@types/prompts": "2.0.3",
     "@types/react": "16.9.17",

--- a/src/framework/app.ts
+++ b/src/framework/app.ts
@@ -10,8 +10,6 @@ import { stripIndent, stripIndents } from 'common-tags'
 import { sendServerReadySignalToDevModeMaster } from './dev-mode'
 import * as singletonChecks from './singleton-checks'
 
-type RequiredValue<T> = T extends null ? never : T extends void ? never : T
-
 const log = pog.sub(__filename)
 
 /**
@@ -64,6 +62,7 @@ type ContextContributor<T extends {}> = (req: Express.Request) => T
 
 export type App = {
   use: (plugin: Plugin.Driver) => App
+  logger: Pino.Logger
   addToContext: <T extends {}>(contextContributor: ContextContributor<T>) => App
   // installGlobally: () => App
   server: {
@@ -85,6 +84,7 @@ export type App = {
  * TODO extract and improve config type
  */
 export function createApp(appConfig?: { types?: any }): App {
+  const logger = createPino()
   const {
     queryType,
     mutationType,
@@ -112,6 +112,7 @@ export function createApp(appConfig?: { types?: any }): App {
    */
 
   const api: App = {
+    logger,
     // TODO bring this back pending future discussion
     // installGlobally() {
     //   installGlobally(api)

--- a/src/framework/app.ts
+++ b/src/framework/app.ts
@@ -9,6 +9,7 @@ import { typegenAutoConfig } from 'nexus/dist/core'
 import { stripIndent, stripIndents } from 'common-tags'
 import { sendServerReadySignalToDevModeMaster } from './dev-mode'
 import * as singletonChecks from './singleton-checks'
+import * as Logger from '../lib/logger'
 
 const log = pog.sub(__filename)
 
@@ -62,7 +63,7 @@ type ContextContributor<T extends {}> = (req: Express.Request) => T
 
 export type App = {
   use: (plugin: Plugin.Driver) => App
-  logger: Pino.Logger
+  logger: Logger.Logger
   addToContext: <T extends {}>(contextContributor: ContextContributor<T>) => App
   // installGlobally: () => App
   server: {
@@ -84,7 +85,7 @@ export type App = {
  * TODO extract and improve config type
  */
 export function createApp(appConfig?: { types?: any }): App {
-  const logger = createPino()
+  const logger = Logger.create()
   const {
     queryType,
     mutationType,

--- a/src/lib/logger/__snapshots__/index.spec.ts.snap
+++ b/src/lib/logger/__snapshots__/index.spec.ts.snap
@@ -1,5 +1,115 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`.<level> log methods accept an event name and optional context 1`] = `
+Array [
+  Object {
+    "context": Object {
+      "user": Object {
+        "id": 1,
+      },
+    },
+    "event": "hi",
+    "hostname": "Jasons-Prisma-Machine.local",
+    "level": 30,
+    "path": Array [
+      "root",
+    ],
+    "pid": 0,
+    "time": 0,
+    "v": 1,
+  },
+  Object {
+    "context": Object {},
+    "event": "bye",
+    "hostname": "Jasons-Prisma-Machine.local",
+    "level": 30,
+    "path": Array [
+      "root",
+    ],
+    "pid": 0,
+    "time": 0,
+    "v": 1,
+  },
+]
+`;
+
+exports[`.<level> log methods one for each log level 1`] = `
+Array [
+  Object {
+    "context": Object {},
+    "event": "hi",
+    "hostname": "Jasons-Prisma-Machine.local",
+    "level": 60,
+    "path": Array [
+      "root",
+    ],
+    "pid": 0,
+    "time": 0,
+    "v": 1,
+  },
+  Object {
+    "context": Object {},
+    "event": "hi",
+    "hostname": "Jasons-Prisma-Machine.local",
+    "level": 50,
+    "path": Array [
+      "root",
+    ],
+    "pid": 0,
+    "time": 0,
+    "v": 1,
+  },
+  Object {
+    "context": Object {},
+    "event": "hi",
+    "hostname": "Jasons-Prisma-Machine.local",
+    "level": 40,
+    "path": Array [
+      "root",
+    ],
+    "pid": 0,
+    "time": 0,
+    "v": 1,
+  },
+  Object {
+    "context": Object {},
+    "event": "hi",
+    "hostname": "Jasons-Prisma-Machine.local",
+    "level": 30,
+    "path": Array [
+      "root",
+    ],
+    "pid": 0,
+    "time": 0,
+    "v": 1,
+  },
+  Object {
+    "context": Object {},
+    "event": "hi",
+    "hostname": "Jasons-Prisma-Machine.local",
+    "level": 20,
+    "path": Array [
+      "root",
+    ],
+    "pid": 0,
+    "time": 0,
+    "v": 1,
+  },
+  Object {
+    "context": Object {},
+    "event": "hi",
+    "hostname": "Jasons-Prisma-Machine.local",
+    "level": 10,
+    "path": Array [
+      "root",
+    ],
+    "pid": 0,
+    "time": 0,
+    "v": 1,
+  },
+]
+`;
+
 exports[`.addToContext can be called multiple times, merging deeply 1`] = `
 Array [
   Object {
@@ -12,6 +122,9 @@ Array [
     "event": "hi",
     "hostname": "Jasons-Prisma-Machine.local",
     "level": 30,
+    "path": Array [
+      "root",
+    ],
     "pid": 0,
     "time": 0,
     "v": 1,
@@ -31,6 +144,9 @@ Array [
     "event": "hi",
     "hostname": "Jasons-Prisma-Machine.local",
     "level": 30,
+    "path": Array [
+      "root",
+    ],
     "pid": 0,
     "time": 0,
     "v": 1,
@@ -49,6 +165,9 @@ Array [
     "event": "hi",
     "hostname": "Jasons-Prisma-Machine.local",
     "level": 30,
+    "path": Array [
+      "root",
+    ],
     "pid": 0,
     "time": 0,
     "v": 1,
@@ -67,6 +186,9 @@ Array [
     "event": "hi",
     "hostname": "Jasons-Prisma-Machine.local",
     "level": 30,
+    "path": Array [
+      "root",
+    ],
     "pid": 0,
     "time": 0,
     "v": 1,
@@ -74,58 +196,35 @@ Array [
 ]
 `;
 
-exports[`has a log method for each log level 1`] = `
+exports[`.child creates a sub logger 1`] = `
 Array [
   Object {
     "context": Object {},
     "event": "hi",
     "hostname": "Jasons-Prisma-Machine.local",
-    "level": 60,
-    "pid": 0,
-    "time": 0,
-    "v": 1,
-  },
-  Object {
-    "context": Object {},
-    "event": "hi",
-    "hostname": "Jasons-Prisma-Machine.local",
-    "level": 50,
-    "pid": 0,
-    "time": 0,
-    "v": 1,
-  },
-  Object {
-    "context": Object {},
-    "event": "hi",
-    "hostname": "Jasons-Prisma-Machine.local",
-    "level": 40,
-    "pid": 0,
-    "time": 0,
-    "v": 1,
-  },
-  Object {
-    "context": Object {},
-    "event": "hi",
-    "hostname": "Jasons-Prisma-Machine.local",
     "level": 30,
+    "path": Array [
+      "root",
+      "tim",
+    ],
     "pid": 0,
     "time": 0,
     "v": 1,
   },
-  Object {
-    "context": Object {},
-    "event": "hi",
-    "hostname": "Jasons-Prisma-Machine.local",
-    "level": 20,
-    "pid": 0,
-    "time": 0,
-    "v": 1,
-  },
+]
+`;
+
+exports[`.child inherits level from parent 1`] = `
+Array [
   Object {
     "context": Object {},
     "event": "hi",
     "hostname": "Jasons-Prisma-Machine.local",
     "level": 10,
+    "path": Array [
+      "root",
+      "tim",
+    ],
     "pid": 0,
     "time": 0,
     "v": 1,
@@ -133,17 +232,87 @@ Array [
 ]
 `;
 
-exports[`log methods accept context 1`] = `
+exports[`.child is unable to change context of siblings 1`] = `
 Array [
   Object {
     "context": Object {
-      "user": Object {
-        "id": 1,
-      },
+      "foo": "bar",
+      "from": "b1",
     },
-    "event": "hi",
+    "event": "foo",
     "hostname": "Jasons-Prisma-Machine.local",
     "level": 30,
+    "path": Array [
+      "root",
+      "b1",
+    ],
+    "pid": 0,
+    "time": 0,
+    "v": 1,
+  },
+  Object {
+    "context": Object {
+      "foo": "bar",
+      "from": "b2",
+    },
+    "event": "foo",
+    "hostname": "Jasons-Prisma-Machine.local",
+    "level": 30,
+    "path": Array [
+      "root",
+      "b2",
+    ],
+    "pid": 0,
+    "time": 0,
+    "v": 1,
+  },
+  Object {
+    "context": Object {
+      "foo": "bar",
+      "from": "b3",
+    },
+    "event": "foo",
+    "hostname": "Jasons-Prisma-Machine.local",
+    "level": 30,
+    "path": Array [
+      "root",
+      "b3",
+    ],
+    "pid": 0,
+    "time": 0,
+    "v": 1,
+  },
+]
+`;
+
+exports[`.child reacts to level changes in root logger 1`] = `
+Array [
+  Object {
+    "context": Object {},
+    "event": "foo",
+    "hostname": "Jasons-Prisma-Machine.local",
+    "level": 10,
+    "path": Array [
+      "root",
+      "b",
+    ],
+    "pid": 0,
+    "time": 0,
+    "v": 1,
+  },
+]
+`;
+
+exports[`output defaults to stdout for all levels 1`] = `
+Array [
+  Object {
+    "context": Object {},
+    "event": "foo",
+    "hostname": "Jasons-Prisma-Machine.local",
+    "level": 60,
+    "path": Array [
+      "root",
+    ],
     "pid": 0,
     "time": 0,
     "v": 1,

--- a/src/lib/logger/__snapshots__/index.spec.ts.snap
+++ b/src/lib/logger/__snapshots__/index.spec.ts.snap
@@ -1,0 +1,152 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.addToContext can be called multiple times, merging deeply 1`] = `
+Array [
+  Object {
+    "context": Object {
+      "user": Object {
+        "id": 1,
+        "name": "Jill",
+      },
+    },
+    "event": "hi",
+    "hostname": "Jasons-Prisma-Machine.local",
+    "level": 30,
+    "pid": 0,
+    "time": 0,
+    "v": 1,
+  },
+]
+`;
+
+exports[`.addToContext gets deeply merged with local context 1`] = `
+Array [
+  Object {
+    "context": Object {
+      "user": Object {
+        "id": 1,
+        "name": "Jill",
+      },
+    },
+    "event": "hi",
+    "hostname": "Jasons-Prisma-Machine.local",
+    "level": 30,
+    "pid": 0,
+    "time": 0,
+    "v": 1,
+  },
+]
+`;
+
+exports[`.addToContext local context takes prescedence over pinned context 1`] = `
+Array [
+  Object {
+    "context": Object {
+      "user": Object {
+        "id": 2,
+      },
+    },
+    "event": "hi",
+    "hostname": "Jasons-Prisma-Machine.local",
+    "level": 30,
+    "pid": 0,
+    "time": 0,
+    "v": 1,
+  },
+]
+`;
+
+exports[`.addToContext pins context for all subsequent logs from the logger 1`] = `
+Array [
+  Object {
+    "context": Object {
+      "user": Object {
+        "id": 1,
+      },
+    },
+    "event": "hi",
+    "hostname": "Jasons-Prisma-Machine.local",
+    "level": 30,
+    "pid": 0,
+    "time": 0,
+    "v": 1,
+  },
+]
+`;
+
+exports[`has a log method for each log level 1`] = `
+Array [
+  Object {
+    "context": Object {},
+    "event": "hi",
+    "hostname": "Jasons-Prisma-Machine.local",
+    "level": 60,
+    "pid": 0,
+    "time": 0,
+    "v": 1,
+  },
+  Object {
+    "context": Object {},
+    "event": "hi",
+    "hostname": "Jasons-Prisma-Machine.local",
+    "level": 50,
+    "pid": 0,
+    "time": 0,
+    "v": 1,
+  },
+  Object {
+    "context": Object {},
+    "event": "hi",
+    "hostname": "Jasons-Prisma-Machine.local",
+    "level": 40,
+    "pid": 0,
+    "time": 0,
+    "v": 1,
+  },
+  Object {
+    "context": Object {},
+    "event": "hi",
+    "hostname": "Jasons-Prisma-Machine.local",
+    "level": 30,
+    "pid": 0,
+    "time": 0,
+    "v": 1,
+  },
+  Object {
+    "context": Object {},
+    "event": "hi",
+    "hostname": "Jasons-Prisma-Machine.local",
+    "level": 20,
+    "pid": 0,
+    "time": 0,
+    "v": 1,
+  },
+  Object {
+    "context": Object {},
+    "event": "hi",
+    "hostname": "Jasons-Prisma-Machine.local",
+    "level": 10,
+    "pid": 0,
+    "time": 0,
+    "v": 1,
+  },
+]
+`;
+
+exports[`log methods accept context 1`] = `
+Array [
+  Object {
+    "context": Object {
+      "user": Object {
+        "id": 1,
+      },
+    },
+    "event": "hi",
+    "hostname": "Jasons-Prisma-Machine.local",
+    "level": 30,
+    "pid": 0,
+    "time": 0,
+    "v": 1,
+  },
+]
+`;

--- a/src/lib/logger/index.spec.ts
+++ b/src/lib/logger/index.spec.ts
@@ -1,0 +1,107 @@
+import * as Logger from './'
+import * as Output from './output'
+
+resetEnvironmentBeforeEachTest()
+
+let logger: Logger.Logger
+let output: MockOutput.MockOutput
+
+beforeEach(() => {
+  output = MockOutput.create()
+  logger = Logger.create({ output })
+})
+
+it('in production the default level is "info"', () => {
+  process.env.NODE_ENV = 'production'
+  expect(Logger.create().level).toEqual('info')
+})
+
+it('outside production the default level is "debug"', () => {
+  process.env.NODE_ENV = 'not-production'
+  expect(Logger.create().level).toEqual('debug')
+})
+
+it('has a log method for each log level', () => {
+  logger.level = 'trace'
+  logger.fatal('hi')
+  logger.error('hi')
+  logger.warn('hi')
+  logger.info('hi')
+  logger.debug('hi')
+  logger.trace('hi')
+  expect(output.writes).toMatchSnapshot()
+})
+
+it('log methods accept context', () => {
+  logger.info('hi', { user: { id: 1 } })
+  expect(output.writes).toMatchSnapshot()
+})
+
+describe('.addToContext', () => {
+  it('pins context for all subsequent logs from the logger', () => {
+    logger.addToContext({ user: { id: 1 } })
+    logger.info('hi')
+    expect(output.writes).toMatchSnapshot()
+  })
+
+  it('can be called multiple times, merging deeply', () => {
+    logger.addToContext({ user: { id: 1 } })
+    logger.addToContext({ user: { name: 'Jill' } })
+    logger.info('hi')
+    expect(output.writes).toMatchSnapshot()
+  })
+
+  it('gets deeply merged with local context', () => {
+    logger.addToContext({ user: { id: 1 } })
+    logger.info('hi', { user: { name: 'Jill' } })
+    expect(output.writes).toMatchSnapshot()
+  })
+
+  it('local context takes prescedence over pinned context', () => {
+    logger.addToContext({ user: { id: 1 } })
+    logger.info('hi', { user: { id: 2 } })
+    expect(output.writes).toMatchSnapshot()
+  })
+
+  it.todo('does not affect parent logger')
+  it.todo('is inherited by child-loggers')
+})
+
+//
+// Helpers
+//
+
+/**
+ * A mock output stream useful for passing to logger and later reflecting on the
+ * values that it wrote.
+ */
+namespace MockOutput {
+  export type MockOutput = Output.Output & {
+    writes: string[]
+  }
+
+  export function create(): MockOutput {
+    const output = {
+      writes: [],
+      write(message: string) {
+        const log: any = JSON.parse(message)
+        log.time = 0
+        log.pid = 0
+        output.writes.push(log)
+      },
+    } as MockOutput
+
+    return output
+  }
+}
+
+/**
+ * Reset the environment before each test, allowing each test to modify it to
+ * its needs.
+ */
+function resetEnvironmentBeforeEachTest() {
+  const originalEnvironment = Object.assign({}, process.env)
+  beforeEach(() => {
+    process.env = Object.assign({}, originalEnvironment)
+  })
+}

--- a/src/lib/logger/index.ts
+++ b/src/lib/logger/index.ts
@@ -1,1 +1,1 @@
-export { create, Logger } from './main'
+export { create, RootLogger as Logger } from './main'

--- a/src/lib/logger/index.ts
+++ b/src/lib/logger/index.ts
@@ -1,0 +1,1 @@
+export { create, Logger } from './main'

--- a/src/lib/logger/main.ts
+++ b/src/lib/logger/main.ts
@@ -1,0 +1,90 @@
+import createPino, { levels } from 'pino'
+import * as Output from './output'
+import * as Lo from 'lodash'
+
+// TODO JSON instead of unknown type
+type Context = Record<string, unknown>
+
+type Log = (event: string, context?: Context) => void
+type LevelLog = (level: Level, event: string, context?: Context) => void
+
+type Level = 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace'
+
+const LEVELS = {
+  fatal: 'fatal',
+  error: 'error',
+  debug: 'debug',
+  warn: 'warn',
+  trace: 'trace',
+  info: 'info',
+} as const
+
+export type Options = {
+  output?: Output.Output
+}
+
+export type Logger = {
+  fatal: Log
+  error: Log
+  warn: Log
+  info: Log
+  debug: Log
+  trace: Log
+  level: Level
+  addToContext: (context: Context) => void
+}
+
+export function create(opts?: Options): Logger {
+  const state = {
+    pinnedContext: {},
+  } as { pinnedContext: Context }
+
+  const pino = createPino(
+    {
+      messageKey: 'event',
+    },
+    opts?.output ?? process.stdout
+  )
+
+  if (process.env.NODE_ENV === 'production') {
+    pino.level = LEVELS.info
+  } else {
+    pino.level = LEVELS.debug
+  }
+
+  const forwardToPino: LevelLog = (level, event, localContext) => {
+    // Avoid mutating the passed local context
+    const context = Lo.merge({}, state.pinnedContext, localContext)
+    pino[level]({ context }, event)
+  }
+
+  return {
+    get level() {
+      return pino.level as Level
+    },
+    set level(level: Level) {
+      pino.level = level
+    },
+    addToContext(context: Context) {
+      Lo.merge(state.pinnedContext, context)
+    },
+    fatal(event, context) {
+      forwardToPino('fatal', event, context)
+    },
+    error(event, context) {
+      forwardToPino('error', event, context)
+    },
+    warn(event, context) {
+      forwardToPino('warn', event, context)
+    },
+    info(event, context) {
+      forwardToPino('info', event, context)
+    },
+    debug(event, context) {
+      forwardToPino('debug', event, context)
+    },
+    trace(event, context) {
+      forwardToPino('trace', event, context)
+    },
+  }
+}

--- a/src/lib/logger/output.ts
+++ b/src/lib/logger/output.ts
@@ -1,0 +1,3 @@
+export type Output = {
+  write: (message: string) => void
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -588,6 +588,18 @@
     "@types/koa-compose" "*"
     "@types/node" "*"
 
+"@types/lodash-es@^4.17.3":
+  version "4.17.3"
+  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.3.tgz#87eb0b3673b076b8ee655f1890260a136af09a2d"
+  integrity sha512-iHI0i7ZAL1qepz1Y7f3EKg/zUMDwDfTzitx+AlHhJJvXwenP682ZyGbgPSc5Ej3eEAKVbNWKFuwOadCj5vBbYQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.149"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
+  integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
+
 "@types/long@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
@@ -623,6 +635,20 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/pino-std-serializers@*":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@types/pino-std-serializers/-/pino-std-serializers-2.4.0.tgz#8cad99175cb79c2448f7455a2d32fb3fde29579c"
+  integrity sha512-eAdu+NW1IkCdmp85SnhyKha+OOREQMT9lXaoICQxa7bhSauRiLzu3WSNt9Mf2piuJvWeXF/G0hGWHr63xNpIRA==
+
+"@types/pino@^5.15.1":
+  version "5.15.1"
+  resolved "https://registry.yarnpkg.com/@types/pino/-/pino-5.15.1.tgz#1d7bfdecbdcb64ec63a672be9bb9524b323f96e4"
+  integrity sha512-skJZ2VBHUva/dF4b2/3zOYVOZLyeaYT7wtPyf8+aoh0VuqfW8JO7PK9oJY8yRZVkN4K7RDdA5UFuH0QbbENZaw==
+  dependencies:
+    "@types/node" "*"
+    "@types/pino-std-serializers" "*"
+    "@types/sonic-boom" "*"
+
 "@types/prompts@2.0.3":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/prompts/-/prompts-2.0.3.tgz#9928714a7a5c2017919f8fecef517369d27dd5df"
@@ -653,6 +679,13 @@
   dependencies:
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
+
+"@types/sonic-boom@*":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@types/sonic-boom/-/sonic-boom-0.7.0.tgz#38337036293992a1df65dd3161abddf8fb9b7176"
+  integrity sha512-AfqR0fZMoUXUNwusgXKxcE9DPlHNDHQp6nKYUd4PSRpLobF5CCevSpyTEBcVZreqaWKCnGBr9KI1fHMTttoB7A==
+  dependencies:
+    "@types/node" "*"
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -2097,6 +2130,16 @@ fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-redact@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-2.0.0.tgz#17bb8f5e1f56ecf4a38c8455985e5eab4c478431"
+  integrity sha512-zxpkULI9W9MNTK2sJ3BpPQrTEXFNESd2X6O1tXMFpK/XM0G5c5Rll2EVYZH2TqI3xRGK/VaJ+eEOt7pnENJpeA==
+
+fast-safe-stringify@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
+  integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
+
 fault@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/fault/-/fault-1.0.3.tgz#4da88cf979b6b792b4e13c7ec836767725170b7e"
@@ -2155,6 +2198,11 @@ find-up@^4.0.0, find-up@^4.1.0:
   dependencies:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
+
+flatstr@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/flatstr/-/flatstr-1.0.12.tgz#c2ba6a08173edbb6c9640e3055b95e287ceb5931"
+  integrity sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -3443,6 +3491,11 @@ lodash.memoize@4.x:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
+lodash.merge@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -4158,6 +4211,23 @@ pify@^4.0.1:
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
+pino-std-serializers@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-2.4.2.tgz#cb5e3e58c358b26f88969d7e619ae54bdfcc1ae1"
+  integrity sha512-WaL504dO8eGs+vrK+j4BuQQq6GLKeCCcHaMB2ItygzVURcL1CycwNEUHTD/lHFHs/NL5qAz2UKrjYWXKSf4aMQ==
+
+pino@^5.15.0:
+  version "5.15.0"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-5.15.0.tgz#6703164ce74dd4786d44887cd33268e13fd463d8"
+  integrity sha512-7+FXMTA3H3sNP5+2miY2K9JKnAAW5GKuhHfNWsukFCsPprGQY3ctqpwbV74wAHW3Nl93cEEQ1G82MgOLM8P7TQ==
+  dependencies:
+    fast-redact "^2.0.0"
+    fast-safe-stringify "^2.0.7"
+    flatstr "^1.0.12"
+    pino-std-serializers "^2.4.2"
+    quick-format-unescaped "^3.0.3"
+    sonic-boom "^0.7.5"
+
 pirates@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
@@ -4290,6 +4360,11 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+quick-format-unescaped@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz#fb3e468ac64c01d22305806c39f121ddac0d1fb9"
+  integrity sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ==
 
 range-parser@~1.2.1:
   version "1.2.1"
@@ -4786,6 +4861,13 @@ snapdragon@^0.8.1:
     source-map "^0.5.6"
     source-map-resolve "^0.5.0"
     use "^3.1.0"
+
+sonic-boom@^0.7.5:
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-0.7.6.tgz#c42df6df884a6a3d54fa7a45b11e4e2196818d45"
+  integrity sha512-k9E2QQ4zxuVRLDW+ZW6ISzJs3wlEorVdmM7ApDgor7wsGKSDG5YGHsGmgLY4XYh4DMlr/2ap2BWAE7yTFJtWnQ==
+  dependencies:
+    flatstr "^1.0.12"
 
 source-map-resolve@^0.5.0:
   version "0.5.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -588,14 +588,7 @@
     "@types/koa-compose" "*"
     "@types/node" "*"
 
-"@types/lodash-es@^4.17.3":
-  version "4.17.3"
-  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.3.tgz#87eb0b3673b076b8ee655f1890260a136af09a2d"
-  integrity sha512-iHI0i7ZAL1qepz1Y7f3EKg/zUMDwDfTzitx+AlHhJJvXwenP682ZyGbgPSc5Ej3eEAKVbNWKFuwOadCj5vBbYQ==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash@*":
+"@types/lodash@^4.14.149":
   version "4.14.149"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
   integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
@@ -3490,11 +3483,6 @@ lodash.memoize@4.x:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
-
-lodash.merge@^4.6.2:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
-  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
 lodash.sortby@^4.7.0:
   version "4.7.0"


### PR DESCRIPTION
relates to #204

To keep work incremental this PR does not:

- deeply integrate with framework yet
- have pretty mode

While we use `pino` I opted to wrap it so we have great autocomplete. Here's what raw pino would look like for our users:

![image](https://user-images.githubusercontent.com/284476/72038083-41cd8200-326e-11ea-9df9-074cdcf17d17.png)


Also, note the scrollbar!!

Like `pino` a lot but I see it more as an engine for us than the thing we should directly expose.

I did not use `pino.child` functionality yet. The reason is that it does have the concept of additive API for context. It only permits passing context to children at child creation time. Our API is more flexible in this regard.