### PR TITLE
improve: log pretty rendering

### DIFF
--- a/src/cli/commands/dev.tsx
+++ b/src/cli/commands/dev.tsx
@@ -10,6 +10,7 @@ import { logger } from '../../utils/logger'
 import { createWatcher } from '../../watcher'
 import { arg, Command, isError } from '../helpers'
 
+const mylogger = logger.child('dev')
 const log = pog.sub('cli:dev')
 
 const DEV_ARGS = {
@@ -116,7 +117,7 @@ export class Dev implements Command {
     }
 
     clearConsole()
-    logger.info('Starting dev server...')
+    mylogger.info('boot')
 
     createWatcher({
       plugins: plugins.map(p => p.hooks),
@@ -131,7 +132,7 @@ export class Dev implements Command {
       onEvent: e => {
         if (state.logMode && e.event === 'restart') {
           clearConsole()
-          logger.info('restarting', { changed: e.file })
+          mylogger.info('restarting', { changed: e.file })
         }
         if (state.logMode && e.event === 'logging') {
           process.stdout.write(e.data)

--- a/src/framework/app.ts
+++ b/src/framework/app.ts
@@ -88,6 +88,7 @@ export type App = {
  */
 export function createApp(appConfig?: { types?: any }): App {
   const logger = Logger.create({ name: 'app' })
+  const serverLogger = logger.child('server')
   const {
     queryType,
     mutationType,
@@ -265,7 +266,7 @@ export function createApp(appConfig?: { types?: any }): App {
         }
 
         const schema = await makeSchema(nexusConfig)
-        const server = new ApolloServer({
+        const apolloServer = new ApolloServer({
           playground: mergedConfig.playground,
           introspection: mergedConfig.introspection,
           // TODO Idea: context that provides an eager object can be hoisted out
@@ -299,12 +300,12 @@ export function createApp(appConfig?: { types?: any }): App {
           schema,
         })
 
-        const app = express()
+        const expressApp = express()
 
-        server.applyMiddleware({ app })
+        apolloServer.applyMiddleware({ app: expressApp })
 
-        app.listen({ port: mergedConfig.port }, () =>
-          api.logger.info('server_listening', {
+        expressApp.listen({ port: mergedConfig.port }, () =>
+          serverLogger.info('listening', {
             host: 'localhost',
             port: mergedConfig.port,
           })

--- a/src/lib/logger/__snapshots__/main.spec.ts.snap
+++ b/src/lib/logger/__snapshots__/main.spec.ts.snap
@@ -341,15 +341,17 @@ Array [
 
 exports[`pretty makes logs pretty 1`] = `
 Array [
-  "[31m✕ fatal root[39m[90m:[39mfoo  [90m--[39m  lib[90m=[39m/see/
+  "[31m✕ fatal root[39m[90m:[39mfoo  [90m--[39m  [90mlib[39m[90m: [39m/see/
 ",
-  "[31m■ error root[39m[90m:[39mfoo  [90m--[39m  har[90m=[39m[object Object]
+  "[31m■ error root[39m[90m:[39mfoo  [90m--[39m  [90mhar[39m[90m: [39m[object Object]
 ",
-  "[33m▲ warn  root[39m[90m:[39mfoo  [90m--[39m  bleep[90m=[39m1,2,true
+  "[33m▲ warn  root[39m[90m:[39mfoo  [90m--[39m  [90mbleep[39m[90m: [39m1,2,true
 ",
-  "[32m● info  root[39m[90m:[39mfoo  [90m--[39m  qux[90m=[39mtrue
+  "[32m● info  root[39m[90m:[39mfoo  [90m--[39m  [90mqux[39m[90m: [39mtrue
 ",
-  "[34m○ debug root[39m[90m:[39mfoo  [90m--[39m  foo[90m=[39mbar
+  "[34m○ debug root[39m[90m:[39mfoo  [90m--[39m  [90mfoo[39m[90m: [39mbar
+",
+  "[35m— trace root[39m[90m:[39mfoo  [90m--[39m  [90ma[39m[90m: [39m1  [90mb[39m[90m: [39m2  [90mc[39m[90m: [39mthree
 ",
 ]
 `;

--- a/src/lib/logger/main.spec.ts
+++ b/src/lib/logger/main.spec.ts
@@ -59,13 +59,13 @@ describe('pretty', () => {
   })
 
   it('makes logs pretty', () => {
-    logger.setPretty(true)
+    logger.setPretty(true).setLevel('trace')
     logger.fatal('foo', { lib: /see/ })
     logger.error('foo', { har: { mar: 'tek' } })
     logger.warn('foo', { bleep: [1, '2', true] })
     logger.info('foo', { qux: true })
     logger.debug('foo', { foo: 'bar' })
-    logger.trace('foo', { a: 1 })
+    logger.trace('foo', { a: 1, b: 2, c: 'three' })
     expect(output.writes).toMatchSnapshot()
   })
 })

--- a/src/lib/logger/prettifier.ts
+++ b/src/lib/logger/prettifier.ts
@@ -1,5 +1,5 @@
 // TODO test
-import chalk from 'chalk'
+import chalk, { Chalk } from 'chalk'
 import * as Logger from './main'
 
 // Helpful unicode pickers:
@@ -49,33 +49,58 @@ const LEVEL_STYLES: Record<
   },
 }
 
+const pathSep = {
+  symbol: ':',
+  color: chalk.gray,
+}
+
+const eventSep = ':'
+
+const contextSep = {
+  symbol: '--',
+  // context = ` ${chalk.gray('⸬')}  ` + context
+  // context = ` ${chalk.gray('•')}  ` + context
+  // context = ` ${chalk.gray('⑊')}  ` + context
+  // context = ` ${chalk.gray('//')}  ` + context
+  // context = ` ${chalk.gray('—')}  ` + context
+  // context = ` ${chalk.gray('~')}  ` + context
+  // context = ` ${chalk.gray('⌀')}  ` + context
+  // context = ` ${chalk.gray('——')}  ` + context
+  // context = ` ${chalk.gray('❯')}  ` + context
+  // context = ` ${chalk.gray('->')}  ` + context
+  // context = ` ${chalk.gray('⌁')}  ` + context
+  // context = ` ${chalk.gray('⋯')}  ` + context
+  // context = ` ${chalk.gray('⌁')}  ` + context
+  // context = ` ${chalk.gray('⟛')}  ` + context
+  color: chalk.gray,
+}
+
+const contextKeyValSep = {
+  symbol: ': ',
+  color: chalk.gray,
+}
+
 export function render(rec: Logger.LogRecord): string {
   const levelLabel = Logger.LEVELS_BY_NUM[rec.level].label
-  const path = rec.path.join('.')
+  const path = rec.path.join(renderEl(pathSep))
   let context = Object.entries(rec.context)
-    .map(e => `${e[0]}${chalk.gray('=')}${e[1]}`)
+    .map(e => `${chalk.gray(e[0])}${renderEl(contextKeyValSep)}${e[1]}`)
     .join('  ')
   if (context) {
-    context = ` ${chalk.gray('--')}  ` + context
-    // context = ` ${chalk.gray('⸬')}  ` + context
-    // context = ` ${chalk.gray('•')}  ` + context
-    // context = ` ${chalk.gray('⑊')}  ` + context
-    // context = ` ${chalk.gray('//')}  ` + context
-    // context = ` ${chalk.gray('—')}  ` + context
-    // context = ` ${chalk.gray('~')}  ` + context
-    // context = ` ${chalk.gray('⌀')}  ` + context
-    // context = ` ${chalk.gray('——')}  ` + context
-    // context = ` ${chalk.gray('❯')}  ` + context
-    // context = ` ${chalk.gray('->')}  ` + context
-    // context = ` ${chalk.gray('⌁')}  ` + context
-    // context = ` ${chalk.gray('⋯')}  ` + context
-    // context = ` ${chalk.gray('⌁')}  ` + context
-    // context = ` ${chalk.gray('⟛')}  ` + context
+    context = ` ${renderEl(contextSep)}  ` + context
   }
   const style = LEVEL_STYLES[levelLabel]
   return `${style.color(
     `${style.badge} ${spaceSuffixSpan5(levelLabel)} ${path}`
-  )}${chalk.gray(':')}${rec.event} ${context}\n`
+  )}${chalk.gray(eventSep)}${rec.event} ${context}\n`
+}
+
+type El = {
+  symbol: string
+  color?: Chalk
+}
+function renderEl(el: El) {
+  return el.color ? el.color(el.symbol) : el.symbol
 }
 
 function spaceSuffixSpan5(content: string): string {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,3 +1,3 @@
 import * as Logger from '../lib/logger'
 
-export const logger = Logger.create({ name: 'framework' })
+export const logger = Logger.create({ name: 'santa' })


### PR DESCRIPTION
- tweak symbols and their coloring for path separation
- tweak key-value symbol separator
- tweak key-value key color
- tweak some of the internal logger names and hierarchy



![image](https://user-images.githubusercontent.com/284476/72163244-74bc6680-3391-11ea-89b8-63ac414bd3be.png)


![image](https://user-images.githubusercontent.com/284476/72163224-6cfcc200-3391-11ea-9cf2-c997e845fd79.png)


example, before, without dimmed keys:

![image](https://user-images.githubusercontent.com/284476/72163277-8867cd00-3391-11ea-88b4-8058167503e6.png)

