### PR TITLE
fix: use explicit default from prompts

### DIFF
--- a/src/cli/commands/create/app.ts
+++ b/src/cli/commands/create/app.ts
@@ -1,6 +1,6 @@
 import { stripIndent } from 'common-tags'
 import * as fs from 'fs-jetpack'
-import prompts from 'prompts'
+import * as prompts from 'prompts'
 import { PackageJson } from 'type-fest'
 import * as Layout from '../../../framework/layout'
 import * as Plugin from '../../../framework/plugin'
@@ -241,7 +241,7 @@ async function askForDatabase(): Promise<
     usePrisma,
   }: {
     usePrisma: boolean
-  } = await prompts({
+  } = await prompts.default({
     type: 'confirm',
     name: 'usePrisma',
     message: 'Do you want to use a database? (https://prisma.io)',
@@ -251,7 +251,7 @@ async function askForDatabase(): Promise<
     return { database: false }
   }
   // TODO the supported databases should come from the plugin driver...
-  let { database }: { database: Database } = await prompts({
+  let { database }: { database: Database } = await prompts.default({
     type: 'select',
     name: 'database',
     message: 'Choose a database',
@@ -282,14 +282,14 @@ async function askForDatabase(): Promise<
   // TODO: Removed temporarily until we have a more solid system to validate the uri,
   // and a textbox where we can the cursor... boohoo prompts
 
-  // let { hasURI }: { hasURI: boolean } = await prompts({
+  // let { hasURI }: { hasURI: boolean } = await prompts.default({
   //   type: 'confirm',
   //   name: 'hasURI',
   //   message: `Do you have a connection URI to connect to your ${database} database?`,
   // })
 
   // if (hasURI) {
-  //   let { connectionURI }: { connectionURI: string } = await prompts({
+  //   let { connectionURI }: { connectionURI: string } = await prompts.default({
   //     type: 'text',
   //     message: `Fill in your connection URI for ${database}`,
   //     name: 'connectionURI',
@@ -319,7 +319,7 @@ async function askForPackageManager(): Promise<
 
   type Result = { packageManagerType: PackageManager.PackageManagerType }
 
-  const result: Result = await prompts({
+  const result: Result = await prompts.default({
     name: 'packageManagerType',
     type: 'select',
     message: 'Please select which package manager you would like to use',

--- a/src/cli/commands/create/plugin.ts
+++ b/src/cli/commands/create/plugin.ts
@@ -4,7 +4,7 @@
  */
 import { stripIndent } from 'common-tags'
 import * as fs from 'fs-jetpack'
-import prompts from 'prompts'
+import * as prompts from 'prompts'
 import { pog, createGitRepository } from '../../../utils'
 import { logger } from '../../../utils/logger'
 import * as proc from '../../../utils/process'
@@ -213,7 +213,7 @@ async function askUserPluginName(): Promise<string> {
   // TODO check the npm registry to see if the name is already taken before
   // continuing.
   //
-  const { pluginName }: { pluginName: string } = await prompts({
+  const { pluginName }: { pluginName: string } = await prompts.default({
     type: 'text',
     name: 'pluginName',
     message: 'What is the name of your plugin?',

--- a/src/framework/plugin.ts
+++ b/src/framework/plugin.ts
@@ -1,7 +1,7 @@
 import { stripIndent } from 'common-tags'
 import { Debugger } from 'debug'
 import * as fs from 'fs-jetpack'
-import prompts from 'prompts'
+import * as prompts from 'prompts'
 import { fatal, pog, run, runSync } from '../utils'
 import { logger } from '../utils/logger'
 import * as PackageManager from '../utils/package-manager'
@@ -153,7 +153,7 @@ export type Lens = {
     /**
      * Check out https://github.com/terkelg/prompts for documentation
      */
-    prompt: typeof prompts
+    prompt: typeof prompts.default
   }
 }
 
@@ -196,7 +196,7 @@ export function create(definer: Definer): DriverCreator {
         run,
         runSync,
         debug: pog.sub(`plugin:${pluginName}`),
-        prompt: prompts,
+        prompt: prompts.default,
       },
     })
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,8 +6,7 @@
     "rootDir": "src",
     "allowJs": true,
     "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true
+    "skipLibCheck": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
closes #171

I think the issue is that `esModuleInterop` TS compiler setting forces consumers to
be as well. And that is not good, since its an ugly detail to interop
with legacy non-es-modules. We do not want santa to be cause for user to
have to turn that compiler option on.